### PR TITLE
set devtools version to 0.2 in example workflow

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -28,7 +28,7 @@ jobs:
       if: github.repository != 'oscar-system/OscarDevTools.jl'
       run: |
         julia --project=oscar-dev -e "using Pkg;
-                                      Pkg.add(\"OscarDevTools\");
+                                      Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
                                       Pkg.instantiate();"
     - id: set-matrix
       run: |
@@ -67,7 +67,7 @@ jobs:
         if: github.repository != 'oscar-system/OscarDevTools.jl'
         run: |
           julia --project=oscar-dev -e "using Pkg;
-                                        Pkg.add(\"OscarDevTools\");
+                                        Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
                                         Pkg.instantiate();"
       - name: "Set up Oscar-dev configuration"
         env:


### PR DESCRIPTION
in preparation for 0.2 bump, and to allow better migration in the future by fixing that version