### PR TITLE
Split Oscar tests by subgroup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.15"
+version = "0.2.16"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/OscarCI.jl
+++ b/src/OscarCI.jl
@@ -316,6 +316,10 @@ function github_env_runtests(job::Dict; varname::String, filename::String)
          else
             if length(get(param, "options", [])) > 0
                push!(testcmd, """Pkg.test("$pkg"; test_args=$(string.(param["options"])));""")
+            elseif pkg == "Oscar"
+               for group in ["short", "book", "long"]
+                  push!(testcmd, """withenv("OSCAR_TEST_SUBSET"=>"$group") do; Pkg.test("$pkg"); end;""")
+               end
             else
                push!(testcmd, """Pkg.test("$pkg");""")
             end


### PR DESCRIPTION
Needs Oscar 1.0.1 (or master), otherwise "group" will run all long+short again...

cc: @thofma