### PR TITLE
Don't add DocumenterMarkdown anymore

### DIFF
--- a/src/OscarCI.jl
+++ b/src/OscarCI.jl
@@ -339,7 +339,6 @@ function github_env_run_doctests(job::Dict; varname::String, filename::String)
               "using Pkg;",
               "Pkg.add(\"Documenter\");",
               "Pkg.add(\"DocumenterCitations\");",
-              "Pkg.add(\"DocumenterMarkdown\");",
               "using Documenter;",
               "include(\"$(@__DIR__)/doctest_helper.jl\");"
              ]


### PR DESCRIPTION
As far as I know, none of our packages use DocumenterMarkdown, and it is incompatible with Documenter 1.0

