### PR TITLE
Only run doctests for packages with enabled tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.18"
+version = "0.2.19"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/OscarCI.jl
+++ b/src/OscarCI.jl
@@ -343,13 +343,15 @@ function github_env_run_doctests(job::Dict; varname::String, filename::String)
               "include(\"$(@__DIR__)/doctest_helper.jl\");"
              ]
    for (pkg, param) in job
-      if get(ENV, "GITHUB_REPOSITORY", "") == "oscar-system/OscarDevTools.jl" &&
-         get(ENV, "OSCARCI_DONT_SKIP", false) != "true"
-         # for oscardevtools itself we just check if the package can be loaded
-         push!(testcmd, """using $pkg;""")
-      else
-         if pkg != "Polymake"
-            push!(testcmd, """using $pkg; @maybe_doctest($pkg);""")
+      if get(param, "test", false)
+         if get(ENV, "GITHUB_REPOSITORY", "") == "oscar-system/OscarDevTools.jl" &&
+            get(ENV, "OSCARCI_DONT_SKIP", false) != "true"
+            # for oscardevtools itself we just check if the package can be loaded
+            push!(testcmd, """using $pkg;""")
+         else
+            if pkg != "Polymake"
+               push!(testcmd, """using $pkg; @maybe_doctest($pkg);""")
+            end
          end
       end
    end


### PR DESCRIPTION
In AbstractAlgebra we have different OscarDevTools-CI-jobs for Nemo, Singular, Hecke, and Oscar. However, the OscarCI job there will run the doctests of all loaded packages.
This will lead to the Hecke doctests being run two times (by HeckeCI and OscarCI), the Nemo doctests being run four times (by HeckeCI, OscarCI, NemoCI, and SingularCI). I just copied the guard from the usual test script generation from a few lines above.