### PR TITLE
include `documenter_helpers.jl` from Oscar if possible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.19"
+version = "0.2.20"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/doctest_helper.jl
+++ b/src/doctest_helper.jl
@@ -44,4 +44,13 @@ macro maybe_doctest(pkg::Symbol)
    end
 end
 
-
+# we include this even when oscar is not tested to add some debug output for
+# printing the doctests and to allow testing of experimental oscar projects
+# (via documenter - walkdir hack)
+oscdep = filter(x -> x.name == "Oscar", collect(values(Pkg.dependencies())))
+if !isempty(oscdep)
+   doc_helpers = joinpath(first(oscdep).source, "docs", "documenter_helpers.jl")
+   if isfile(doc_helpers)
+      include(doc_helpers)
+   end
+end

--- a/test/meta/OscarCI-PR.toml
+++ b/test/meta/OscarCI-PR.toml
@@ -3,7 +3,7 @@ title = "metadata for oscar CI run"
 # keep it small to prevent job-explosion
 [env]
 os = [ "ubuntu-latest" ]
-julia-version = [ "~1.6.0-0" ]
+julia-version = [ "~1.10.0-0" ]
 
 # for OscarDevTools we mostly use release versions
 [pkgs]
@@ -25,5 +25,5 @@ julia-version = [ "~1.6.0-0" ]
   Oscar = "master"
   Polymake = "master"
   os = "macos-latest"
-  julia-version = "~1.6.0-0"
+  julia-version = "~1.10.0-0"
 

--- a/test/meta/OscarCI-legacy.toml
+++ b/test/meta/OscarCI-legacy.toml
@@ -13,5 +13,5 @@ Oscar = [ "release" ]
   [include.julia]
   Oscar = "master"
   Polymake = "release"
-  julia-version = "1.7"
+  julia-version = "1.10"
   os = "macos-latest"


### PR DESCRIPTION
For debug output and walkdir hack.
Doc-Testing oscar experimental projects also needs: https://github.com/oscar-system/Oscar.jl/pull/4083

Update some versions for testing.