### PR TITLE
use ubuntu 22.04 instead of latest by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.20"
+version = "0.2.21"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -1,7 +1,9 @@
 ######
 ### defaults for julia-version, os and branches
 
-const default_os = [ "ubuntu-latest" ]
+# we stick with ubuntu 22 until we can remove julia 1.6 due to GLIBCXX errors
+# from polymake wrappers
+const default_os = [ "ubuntu-22.04" ]
 const default_julia = [ "~1.6.0-0", "~1.10.0-0" ]
 const default_branches = [ "<matching>", "release" ]
 


### PR DESCRIPTION
This should avoid some GLIBCXX errors with julia 1.6.
Note: the rollout has been [put on hold](https://github.com/actions/runner-images/issues/10636) but it is still better to fix this for now.