### PR TITLE
Revert "stick with ubuntu 22.04 for now"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -1,9 +1,7 @@
 ######
 ### defaults for julia-version, os and branches
 
-# we stick with ubuntu 22 until we can remove julia 1.6 due to GLIBCXX errors
-# from polymake wrappers
-const default_os = [ "ubuntu-22.04" ]
+const default_os = [ "ubuntu-latest" ]
 const default_julia = [ "~1.6.0-0", "~1.10.0-0" ]
 const default_branches = [ "<matching>", "release" ]
 


### PR DESCRIPTION
this messes with the labels (for branch protection rules)
also there is a new polymake_oscarnumber_jll which should fix the wrapper issue for now

This reverts commit 6035e8b.