### PR TITLE
doctest: add optional doctest filters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/doctest_helper.jl
+++ b/src/doctest_helper.jl
@@ -23,8 +23,9 @@ end
 function doctest_cmd(pkg::Symbol)
    mod = getproperty(@__MODULE__, pkg)
    setup = QuoteNode(isdefined(mod, :doctestsetup) ? mod.doctestsetup() : :(using $(pkg)))
+   filters = isdefined(mod, :doctestfilters) ? mod.doctestfilters() : []
    return quote
-             DocMeta.setdocmeta!($pkg, :DocTestSetup, $setup; recursive = true); doctest($pkg)
+             DocMeta.setdocmeta!($pkg, :DocTestSetup, $setup; recursive = true); doctest($pkg; doctestfilters=$filters)
           end
 end
 


### PR DESCRIPTION
uses the filters from: https://github.com/oscar-system/Oscar.jl/pull/4873
probably not urgent as I don't think we are running OscarCI with nightly currently.
cc: @lgoettgens 