### PR TITLE
Drop julia 1.6 from OscarCI defaults

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.23"
+version = "0.2.24"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -2,7 +2,7 @@
 ### defaults for julia-version, os and branches
 
 const default_os = [ "ubuntu-latest" ]
-const default_julia = [ "~1.6.0-0", "~1.10.0-0" ]
+const default_julia = [ "~1.10.0-0" ]
 const default_branches = [ "<matching>", "release" ]
 
 # for each package this contains an ordered list with


### PR DESCRIPTION
https://github.com/oscar-system/Oscar.jl/issues/4200#issuecomment-2983534243 says that we want to do this as the first step towards https://github.com/oscar-system/Oscar.jl/issues/4200, if nobody objects at the Friday Meeting on June 20th. I wasn't at that meeting, but nobody wrote an objection to https://github.com/oscar-system/Oscar.jl/issues/4200.