### PR TITLE
also run `build_doc` for oscar > 1.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 GitHub = "^5.4"
-JSON = "^0.21"
+JSON = "^0.21, ^1.0"
 TOML = "^1.0"
 julia = "^1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.25"
+version = "0.2.26"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -9,7 +9,7 @@ const default_branches = [ "<matching>", "release" ]
 # pkg-version -> pair of lower and upper bound, more precisely:
 # if pkgversion >= $version then check $lower <= julia_version < $upper
 # newest entries should come first
-# if no matching version is found the doctests will run with julia 1.6
+# if no matching version is found the doctests will run with julia 1.10
 const doctest_versions = Dict(
     :Oscar           => [v"0.14.0-DEV" => (v"1.10", v"1.12"),
                          v"0.13.0-DEV" => (v"1.9" , v"1.11"),

--- a/src/doctest_helper.jl
+++ b/src/doctest_helper.jl
@@ -24,7 +24,16 @@ function doctest_cmd(pkg::Symbol)
    mod = getproperty(@__MODULE__, pkg)
    setup = QuoteNode(isdefined(mod, :doctestsetup) ? mod.doctestsetup() : :(using $(pkg)))
    filters = isdefined(mod, :doctestfilters) ? mod.doctestfilters() : []
-   docbuild = pkg === :Oscar ? :( Oscar.build_doc(;doctest=false, warnonly=false, open_browser=false) ) : :()
+   docbuild = pkg === :Oscar ?
+      :(
+        tmpdir = mktempdir();
+        projfile = joinpath(tmpdir, "Project.toml");
+        cp(joinpath(Oscar.oscardir, "docs", "Project.toml"), projfile);
+        chmod(projfile, filemode(projfile) | 0o200);
+        Oscar.doc_init(;path=tmpdir);
+        Oscar.build_doc(; doctest=false, warnonly=false, open_browser=false)
+       ) :
+      :()
    return quote
              DocMeta.setdocmeta!($pkg, :DocTestSetup, $setup; recursive = true); doctest($pkg; doctestfilters=$filters); $docbuild;
           end

--- a/src/doctest_helper.jl
+++ b/src/doctest_helper.jl
@@ -7,41 +7,38 @@ include("defaults.jl")
 
 function allow_doctests(pkg::Symbol, julia_version=VERSION)
    dep = first(filter(d->d.name == string(pkg), collect(values(Pkg.dependencies()))))
+   docs_mode = :doctest
+   if pkg === :Oscar && dep.version > v"1.7.0"
+      docs_mode = :test_and_build
+   end
 
    if haskey(doctest_versions, pkg)
       for (pv, jvb) in doctest_versions[pkg]
          if dep.version >= pv
-            return first(jvb) <= julia_version < last(jvb)
+            return first(jvb) <= julia_version < last(jvb) ? docs_mode : nothing
          end
       end
    end
 
    # fallback to LTS
-   return v"1.10" <= julia_version < v"1.11"
+   return v"1.10" <= julia_version < v"1.11" ? docs_mode : nothing
 end
 
-function doctest_cmd(pkg::Symbol)
+function doctest_cmd(pkg::Symbol; docs_mode=:doctest)
    mod = getproperty(@__MODULE__, pkg)
    setup = QuoteNode(isdefined(mod, :doctestsetup) ? mod.doctestsetup() : :(using $(pkg)))
    filters = isdefined(mod, :doctestfilters) ? mod.doctestfilters() : []
-   docbuild = pkg === :Oscar ?
-      :(
-        tmpdir = mktempdir();
-        projfile = joinpath(tmpdir, "Project.toml");
-        cp(joinpath(Oscar.oscardir, "docs", "Project.toml"), projfile);
-        chmod(projfile, filemode(projfile) | 0o200);
-        Oscar.doc_init(;path=tmpdir);
-        Oscar.build_doc(; doctest=false, warnonly=false, open_browser=false)
-       ) :
-      :()
+   docbuild = pkg === :Oscar && docs_mode === :test_and_build ?
+      :( Oscar.build_doc(; doctest=false, warnonly=false, open_browser=false) ) : :()
    return quote
              DocMeta.setdocmeta!($pkg, :DocTestSetup, $setup; recursive = true); doctest($pkg; doctestfilters=$filters); $docbuild;
           end
 end
 
 macro maybe_doctest(pkg::Symbol)
-   if allow_doctests(pkg)
-      return doctest_cmd(pkg)
+   docs_mode = allow_doctests(pkg)
+   if docs_mode !== nothing
+      return doctest_cmd(pkg; docs_mode)
    else
       msg = "Skipping doctest for $pkg due to julia version ($VERSION) mismatch."
       if haskey(ENV, "GITHUB_STEP_SUMMARY")

--- a/src/doctest_helper.jl
+++ b/src/doctest_helper.jl
@@ -17,15 +17,16 @@ function allow_doctests(pkg::Symbol, julia_version=VERSION)
    end
 
    # fallback to LTS
-   return v"1.6" <= julia_version < v"1.7"
+   return v"1.10" <= julia_version < v"1.11"
 end
 
 function doctest_cmd(pkg::Symbol)
    mod = getproperty(@__MODULE__, pkg)
    setup = QuoteNode(isdefined(mod, :doctestsetup) ? mod.doctestsetup() : :(using $(pkg)))
    filters = isdefined(mod, :doctestfilters) ? mod.doctestfilters() : []
+   docbuild = pkg === :Oscar ? :( Oscar.build_doc(;doctest=false, warnonly=false, open_browser=false) ) : :()
    return quote
-             DocMeta.setdocmeta!($pkg, :DocTestSetup, $setup; recursive = true); doctest($pkg; doctestfilters=$filters)
+             DocMeta.setdocmeta!($pkg, :DocTestSetup, $setup; recursive = true); doctest($pkg; doctestfilters=$filters); $docbuild;
           end
 end
 


### PR DESCRIPTION
I think there should be one job that actually runs the docs and thus should also run the docs build.
I also updated the fallback LTS version to 1.10.

might fix https://github.com/oscar-system/Oscar.jl/issues/5819 and fix https://github.com/oscar-system/OscarDevTools.jl/issues/45