### PR TITLE
Ignore dependabot branches when looking for matching branch names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OscarDevTools"
 uuid = "4f01c588-2833-446a-9dbd-6331d80acb41"
 authors = ["Benjamin Lorenz <lorenz@math.tu-berlin.de>"]
-version = "0.2.26"
+version = "0.2.27"
 
 [deps]
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"

--- a/src/OscarCI.jl
+++ b/src/OscarCI.jl
@@ -116,7 +116,8 @@ function ci_matrix(meta::Dict{String,Any}; pr=0, fork=nothing, active_repo=nothi
             # otherwise use the username of the creator of the PR
             fork = ghpr.user.login
          end
-         if startswith(ghpr.head.ref, "$(ghpr.user.login)-patch-")
+         if startswith(ghpr.head.ref, "$(ghpr.user.login)-patch-") ||
+            startswith(ghpr.head.ref, "dependabot/")
             @warn "PR branch name $(ghpr.head.ref) ignored for branch autodetection"
             if !("master" in global_branches)
                fork = nothing


### PR DESCRIPTION
Resolves https://github.com/oscar-system/OscarDevTools.jl/issues/53.